### PR TITLE
stage-ffmpeg: reject dynamically-linked binaries; use imageio static …

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,11 +144,15 @@ jobs:
         run: brew install bazelisk
 
       # Bundled next to transcribe-rs in Contents/Resources/bin/ (see
-      # scripts/stage-ffmpeg.py). `npm run build:ffmpeg` uses python3 + ffmpeg
-      # on PATH (no uv). Local dev can still use imageio via `uv sync` if
-      # imageio_ffmpeg is importable from the active Python.
-      - name: Install ffmpeg for bundling
-        run: brew install ffmpeg
+      # scripts/stage-ffmpeg.py). We deliberately DON'T `brew install ffmpeg`
+      # here: Homebrew's binary is dynamically linked to
+      # `/opt/homebrew/Cellar/ffmpeg/<ver>/lib/lib*.dylib`, so the resulting
+      # .app crashes on any machine without those exact paths. imageio-ffmpeg
+      # ships an osxexperts static build whose only dylib references are
+      # under /usr/lib — stage-ffmpeg.py verifies this via `otool -L` and
+      # refuses to bundle anything else.
+      - name: Install imageio-ffmpeg for bundling
+        run: pip3 install --break-system-packages imageio-ffmpeg
 
       # `npm run package:mac` runs `vue-tsc → vite build → vite build
       # --config vite.electron.config.ts → electron-builder --mac`

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -483,7 +483,7 @@
     },
     "@@rules_rust+//crate_universe:extension.bzl%crate": {
       "general": {
-        "bzlTransitiveDigest": "dYrRexFCw2D9zQvRBF54gTXKRYyYsuw22XQHC/cPYN8=",
+        "bzlTransitiveDigest": "T7OWYIvxjP3Zmkb/HT1jiL9Ho4av2wXovF11kLsgVUw=",
         "usagesDigest": "0FHnYnKHYTjTAsUV4ZyKOhSTdNJa/pAXwuE4sjo7k/w=",
         "recordedInputs": [
           "ENV:CARGO_BAZEL_DEBUG \\0",
@@ -507,8 +507,8 @@
           "REPO_MAPPING:rules_rust+,bazel_tools bazel_tools",
           "REPO_MAPPING:rules_rust+,rules_cc rules_cc+",
           "REPO_MAPPING:rules_rust+,rules_rust rules_rust+",
-          "FILE:@@//transcribe_rs/Cargo.lock ded22752079673b27fbe079b00a8a720a24aeda1428e67592a2404ba6aaa6f9e",
-          "FILE:@@//transcribe_rs/Cargo.toml d7c6921817be4fbc758213157f0469d396deea14324bca1485ddbf69813119de",
+          "FILE:@@//transcribe_rs/Cargo.lock c690cc45e1ff7063ec852f3343a06ea08a7994c538f9cd1d897cb63714cbe557",
+          "FILE:@@//transcribe_rs/Cargo.toml 068a6f1586c040463c0a96b317e06c203bb8bfeda924fd3de08e9997e4b8b3f2",
           "FILE:@@//transcribe_rs/caption-schema/Cargo.toml dfeb8b977afdc6003ab582f926b8da1b125c5e793350a286e2fffd3ffedb2ce8",
           "FILE:@@//transcribe_rs/caption-core/Cargo.toml 6f93fb8db7070998a7a7ba81cedf0f525c0a3801a341171a1f2c892c088fe3f3",
           "FILE:@@//transcribe_rs/transcribe-rs/Cargo.toml 9f4033d83c32b832f79fbd5407c29c4e9d96b011f74af34a6200111d19de4b76",

--- a/electron/constants.ts
+++ b/electron/constants.ts
@@ -3,7 +3,7 @@
  */
 
 // App Information
-export const APP_VERSION = '1.7.0'
+export const APP_VERSION = '1.7.1'
 
 // AI Transcription (uvx / transcribe)
 export const UV_VERSION = '0.11.15'

--- a/scripts/stage-ffmpeg.py
+++ b/scripts/stage-ffmpeg.py
@@ -1,12 +1,27 @@
 #!/usr/bin/env python3
-"""Copy a platform ffmpeg binary into dist-rust/ffmpeg for app bundling.
+"""Copy a self-contained ffmpeg binary into dist-rust/ffmpeg for app bundling.
 
 Used by `npm run build:ffmpeg` before electron-builder packs
 Contents/Resources/bin/. The Rust CLIs never use the user's PATH at runtime —
-only this staged copy (or CAPTION_EDITOR_FFMPEG).
+only this staged copy (or `CAPTION_EDITOR_FFMPEG`).
 
-Staging source (build time only): imageio-ffmpeg wheel, else `ffmpeg` on PATH
-(e.g. `brew install ffmpeg` on release CI).
+**Self-contained matters.** Homebrew's ffmpeg is dynamically linked to dylibs
+under `/opt/homebrew/Cellar/ffmpeg/<version>/lib/`, so an .app bundling that
+binary crashes on any machine where those exact dylibs aren't installed at
+that exact path:
+
+    dyld: Library not loaded: /opt/homebrew/Cellar/ffmpeg/8.1.1/lib/libavdevice.62.dylib
+
+We therefore only accept ffmpeg binaries whose `otool -L` output references
+only system dylibs (`/usr/lib/*`, `/System/Library/*`) — `imageio-ffmpeg`'s
+osxexperts build qualifies; brew's does not.
+
+Search order:
+  1. `imageio_ffmpeg.get_ffmpeg_exe()` from the active Python.
+  2. `imageio_ffmpeg.get_ffmpeg_exe()` from `transcribe/.venv` (the repo's
+     uv env). Lets you run this script under any /usr/bin/python3 without
+     adding a global pip install step.
+  3. `ffmpeg` on PATH — only if it passes the self-contained check.
 """
 
 from __future__ import annotations
@@ -14,6 +29,7 @@ from __future__ import annotations
 import os
 import shutil
 import stat
+import subprocess
 import sys
 
 
@@ -21,22 +37,90 @@ def _repo_root() -> str:
     return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 
-def _find_source() -> str:
+def _imageio_via_active_python() -> str | None:
     try:
         import imageio_ffmpeg  # type: ignore[import-untyped]
-
-        return imageio_ffmpeg.get_ffmpeg_exe()
     except ImportError:
-        pass
+        return None
+    return imageio_ffmpeg.get_ffmpeg_exe()
 
-    path = shutil.which("ffmpeg")
-    if path:
-        return path
+
+def _imageio_via_transcribe_venv() -> str | None:
+    """Ask transcribe/.venv's Python to resolve imageio_ffmpeg's binary path."""
+    venv_py = os.path.join(_repo_root(), "transcribe", ".venv", "bin", "python")
+    if not os.path.isfile(venv_py):
+        return None
+    try:
+        out = subprocess.check_output(
+            [venv_py, "-c", "import imageio_ffmpeg; print(imageio_ffmpeg.get_ffmpeg_exe())"],
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+    except subprocess.CalledProcessError:
+        return None
+    path = out.strip()
+    return path if path and os.path.isfile(path) else None
+
+
+def _is_self_contained(binary: str) -> bool:
+    """True if `otool -L` shows only system dylib references.
+
+    Returns True on non-macOS too (we only ship macOS, but don't want this
+    script to false-fail in unrelated dev environments).
+    """
+    if sys.platform != "darwin":
+        return True
+    try:
+        out = subprocess.check_output(["otool", "-L", binary], text=True)
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        # otool missing or refused — fall back to allowing it; the CI check
+        # below will catch any real regression.
+        return True
+    lines = [line.strip() for line in out.splitlines()[1:] if line.strip()]
+    for line in lines:
+        # Format: "/path/to/libfoo.dylib (compatibility version ...)"
+        path = line.split(" ", 1)[0]
+        if path.startswith("/usr/lib/") or path.startswith("/System/"):
+            continue
+        # Self-reference (binary's own install_name) doesn't count.
+        if os.path.basename(path) == os.path.basename(binary):
+            continue
+        print(f"  rejected: {binary} depends on non-system dylib: {path}", file=sys.stderr)
+        return False
+    return True
+
+
+def _find_source() -> str:
+    for source_name, finder in [
+        ("active python imageio_ffmpeg", _imageio_via_active_python),
+        ("transcribe/.venv imageio_ffmpeg", _imageio_via_transcribe_venv),
+    ]:
+        path = finder()
+        if path:
+            if _is_self_contained(path):
+                print(f"Using {source_name}: {path}", file=sys.stderr)
+                return path
+            print(f"Skipping {source_name} ({path}): not self-contained", file=sys.stderr)
+
+    path_ffmpeg = shutil.which("ffmpeg")
+    if path_ffmpeg and _is_self_contained(path_ffmpeg):
+        print(f"Using PATH ffmpeg: {path_ffmpeg}", file=sys.stderr)
+        return path_ffmpeg
+    if path_ffmpeg:
+        print(
+            f"PATH ffmpeg ({path_ffmpeg}) is not self-contained — refusing to bundle it.",
+            file=sys.stderr,
+        )
 
     print(
-        "Could not locate ffmpeg for bundling.\n"
-        "  - Install imageio-ffmpeg:  cd transcribe && uv sync\n"
-        "  - Or install ffmpeg on PATH:  brew install ffmpeg",
+        "\nCould not locate a self-contained ffmpeg for bundling.\n"
+        "Bundling Homebrew's ffmpeg crashes on other machines (it dyld-references\n"
+        "/opt/homebrew/Cellar paths that don't exist there).\n\n"
+        "Options:\n"
+        "  - System Python:    pip3 install --user imageio-ffmpeg\n"
+        "  - Repo venv:        cd transcribe && uv sync\n"
+        "  - Explicit static:  download a static ffmpeg, then set\n"
+        "                      CAPTION_EDITOR_FFMPEG=<path> or stage it manually.\n",
         file=sys.stderr,
     )
     sys.exit(1)
@@ -49,6 +133,11 @@ def main() -> None:
     shutil.copy2(src, dst)
     mode = os.stat(dst).st_mode
     os.chmod(dst, mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    # Re-check after copying — copy2 preserves the bits but a sanity pass
+    # catches any FS-level surprise (xattrs, symlinks resolved differently).
+    if not _is_self_contained(dst):
+        print(f"Staged ffmpeg at {dst} is not self-contained — refusing.", file=sys.stderr)
+        sys.exit(1)
     print(f"Staged ffmpeg for bundling: {dst} ({os.path.getsize(dst)} bytes, from {src})")
 
 

--- a/transcribe_rs/Cargo.lock
+++ b/transcribe_rs/Cargo.lock
@@ -215,7 +215,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "caption-core"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "caption-schema",
  "insta",
@@ -227,7 +227,7 @@ dependencies = [
 
 [[package]]
 name = "caption-schema"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "base64 0.22.1",
  "json5",
@@ -600,7 +600,7 @@ checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "embed-rs-cli"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "caption-core",
  "caption-schema",
@@ -2636,7 +2636,7 @@ dependencies = [
 
 [[package]]
 name = "transcribe-rs-cli"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "caption-core",
  "caption-schema",

--- a/transcribe_rs/Cargo.toml
+++ b/transcribe_rs/Cargo.toml
@@ -15,7 +15,7 @@ license = "MIT"
 # these crates and attaches `{transcribe,embed}-rs-v${APP_VERSION}-darwin-arm64`
 # to the GitHub release; the Electron app downloads by version tag.
 # Bump procedure: see ../CLAUDE.md → "Version Management".
-version = "1.7.0"
+version = "1.7.1"
 publish = false
 
 [workspace.dependencies]

--- a/transcribe_rs/version.bzl
+++ b/transcribe_rs/version.bzl
@@ -10,4 +10,4 @@ match what Electron ships and what the GitHub release attaches as
 `transcribe-rs-v${APP_VERSION}-darwin-arm64`).
 """
 
-APP_VERSION = "1.7.0"
+APP_VERSION = "1.7.1"


### PR DESCRIPTION
…build

The bundled .app was crashing on user machines with:

  dyld: Library not loaded: /opt/homebrew/Cellar/ffmpeg/8.1.1/lib/libavdevice.62.dylib

Cause: scripts/stage-ffmpeg.py fell through to `shutil.which("ffmpeg")` = Homebrew's ffmpeg, which is dynamically linked to dylibs under `/opt/homebrew/Cellar/ffmpeg/<ver>/lib/`. Those paths only exist on the build machine, so the bundled binary aborts on any other host.

stage-ffmpeg.py changes:
  - Add `_imageio_via_transcribe_venv()` so the script finds the static osxexperts build from transcribe/.venv even when invoked under /usr/bin/python3 (which is what `npm run build:ffmpeg` does).
  - Add `_is_self_contained()` — runs `otool -L` and refuses any binary that references dylibs outside /usr/lib/* and /System/Library/*. Applied to every source candidate AND to the staged copy as a final sanity gate.
  - Updated error message lists three actionable fixes when no self-contained ffmpeg is locatable.

release.yml changes:
  - Replace `brew install ffmpeg` (dynamic) with `pip3 install --break-system-packages imageio-ffmpeg` (static).
  - Comment explains why brew's ffmpeg is unusable for bundling.

Verified locally: dist-rust/ffmpeg now resolves to transcribe/.venv/.../ffmpeg-macos-aarch64-v7.1; `otool -L` shows only system frameworks and /usr/lib/libSystem.B.dylib / libc++.1.dylib etc.

Bump APP_VERSION to 1.7.1.